### PR TITLE
Fix typos in usage examples

### DIFF
--- a/src/mfcuk.c
+++ b/src/mfcuk.c
@@ -719,10 +719,10 @@ static void print_usage(FILE *fp, const char *prog_name)
   fprintf(fp, "\n");
 
   fprintf(fp, "Usage examples:\n");
-  fprintf(fp, "  Recove all keys from all sectors:\n");
+  fprintf(fp, "  Recover all keys from all sectors:\n");
   fprintf(fp, "    %s -C -R -1\n", prog_name);
 
-  fprintf(fp, "  Recove the sector #0 key with 250 ms for all delays (delays could give more results): \n");
+  fprintf(fp, "  Recover the sector #0 key with 250 ms for all delays (delays could give more results): \n");
   fprintf(fp, "    %s -C -R 0 -s 250 -S 250\n", prog_name);
   return;
 }


### PR DESCRIPTION
Just a small change- added an R to the proper words.